### PR TITLE
Link to all guides in current version, in order

### DIFF
--- a/app/content/loaders/guides.rb
+++ b/app/content/loaders/guides.rb
@@ -1,20 +1,39 @@
 # frozen_string_literal: true
 
+require "yaml"
+
 module Site
   module Content
     module Loaders
       # Loads guides from content/guides/ into the database.
       class Guides
+        GUIDES_YML = "guides.yml"
+        GUIDES_KEY = :guides
+
         include Deps[relation: "relations.guides"]
 
         def call(root: GUIDES_PATH)
-          # Prepare an array of paths like "hanami/v2.2/views".
-          guide_paths = root.glob("*/*/*").map { _1.relative_path_from(root).to_s }
+          # Find all per-org guide versions: ["hanami/v2.2", ...]
+          org_guide_versions = root.glob("*/*").map { it.relative_path_from(root).to_s }
 
-          guide_paths.each do |guide_path|
+          # For each versioned set of guides, load the available guides (in order) from guides.yml
+          guide_paths = org_guide_versions.each_with_object([]) { |org_guide_version, memo_arr|
+            guides_yml = GUIDES_PATH.join(org_guide_version, GUIDES_YML)
+            next unless guides_yml.file?
+
+            versioned_guides = File.read(guides_yml)
+              .then { YAML.load(it, symbolize_names: true) }
+              .fetch(GUIDES_KEY)
+              .map { File.join(org_guide_version, it) }
+
+            memo_arr.concat versioned_guides
+          }
+
+          # Insert a record for each guide
+          guide_paths.each_with_index do |guide_path, position|
             org, version, slug = guide_path.split("/")
 
-            relation.insert(org:, slug:, version:)
+            relation.insert(org:, slug:, version:, position:)
           end
         end
       end

--- a/app/relations/guides.rb
+++ b/app/relations/guides.rb
@@ -6,6 +6,7 @@ module Site
       schema :guides do
         attribute :org, Types::Nominal::String
         attribute :slug, Types::Nominal::String
+        attribute :position, Types::Nominal::Integer
         attribute :version, Types::Nominal::String
       end
     end

--- a/app/repos/guide_repo.rb
+++ b/app/repos/guide_repo.rb
@@ -6,6 +6,10 @@ module Site
       def find(org:, version:, slug:)
         guides.where(org:, version:, slug:).one!
       end
+
+      def all(org:, version:)
+        guides.where(org:, version:).to_a
+      end
     end
   end
 end

--- a/app/structs/guide.rb
+++ b/app/structs/guide.rb
@@ -7,12 +7,16 @@ module Site
         @pages ||= Content::MultiPageCollection.new(relative_content_path)
       end
 
-      def path
+      def url_path
+        relative_content_path
+      end
+
+      def content_path
         Content::GUIDES_PATH.join(org, version, slug)
       end
 
       def relative_content_path
-        path.relative_path_from(Content::CONTENT_PATH)
+        content_path.relative_path_from(Content::CONTENT_PATH)
       end
     end
   end

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -1,3 +1,15 @@
+<h2>All guides</h1>
+<ol data-testid="guides-list">
+  <% all_guides.each do |guide| %>
+    <li>
+      <a href="<%= guide.url_path %>">
+        <%# TODO: put full guide title here %>
+        <%= guide.url_path %>
+      </a>
+    </li>
+  <% end %>
+<ol>
+
 <h1>Guide: <%= guide.slug %></h1>
 
 <h1>Page: <%= page.title %></h1>

--- a/app/views/guides/show.rb
+++ b/app/views/guides/show.rb
@@ -13,6 +13,10 @@ module Site
         expose :page do |guide, path:|
           guide.pages.page_at(path)
         end
+
+        expose :all_guides do |org:, version:|
+          guide_repo.all(org:, version:)
+        end
       end
     end
   end

--- a/content/guides/hanami/v2.2/guides.yml
+++ b/content/guides/hanami/v2.2/guides.yml
@@ -1,0 +1,13 @@
+guides:
+  - getting-started
+  - command-line
+  - app
+  - database
+  - routing
+  - actions
+  - operations
+  - views
+  - helpers
+  - logger
+  - assets
+  - upgrade-notes

--- a/spec/features/guides_spec.rb
+++ b/spec/features/guides_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Guides" do
   it "shows a list of all the guide's pages" do
     visit "/guides/hanami/v2.2/views"
 
-    within("[data-testid=guide-toc]") do
+    within "[data-testid=guide-toc]" do
       expect(page).to have_selector "li:nth-child(1)", text: "Overview"
       expect(page).to have_selector "li:nth-child(2)", text: "Context"
     end
@@ -27,11 +27,25 @@ RSpec.feature "Guides" do
   it "shows a table of contents for the current page" do
     visit "/guides/hanami/v2.2/views/context"
 
-    within("[data-testid=page-toc]") do
+    within "[data-testid=page-toc]" do
       expect(page).to have_selector "li:nth-child(1)", text: "Standard context"
       expect(page).to have_selector "li:nth-child(2)", text: "Customizing the standard context"
       expect(page).to have_selector "li:nth-child(3)", text: "Decorating context attributes"
       expect(page).to have_selector "li:nth-child(4)", text: "Providing an alternative context object"
+    end
+  end
+
+  it "links to the other guides, in correct order" do
+    visit "/guides/hanami/v2.2/views"
+
+    within "[data-testid=guides-list]" do
+      all_guide_names = page.find_all("li a").map(&:text)
+
+      expect(all_guide_names[0..2]).to eq [
+        "guides/hanami/v2.2/getting-started",
+        "guides/hanami/v2.2/command-line",
+        "guides/hanami/v2.2/app"
+      ]
     end
   end
 end


### PR DESCRIPTION
Instead of loading guides by detecthing them from the filesystem, load them from a guides.yml at the root of each version dir, allowing the available guides and their order to be specified manually.