### PR TITLE
Add guides index page showing guides for all current versions

### DIFF
--- a/app/actions/guides/index.rb
+++ b/app/actions/guides/index.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Site
+  module Actions
+    module Guides
+      class Index < Site::Action
+        def handle(request, response)
+        end
+      end
+    end
+  end
+end

--- a/app/content.rb
+++ b/app/content.rb
@@ -2,8 +2,13 @@
 
 module Site
   module Content
-    CONTENT_PATH = App.root.join("content").freeze
+    DEFAULT_GUIDE_VERSIONS = {
+      "dry-rb" => "v1.0",
+      "hanami" => "v2.2",
+      "rom" => "v5.0"
+    }.freeze
 
+    CONTENT_PATH = App.root.join("content").freeze
     DOCS_PATH = CONTENT_PATH.join("docs").freeze
     GUIDES_PATH = CONTENT_PATH.join("guides").freeze
 

--- a/app/repos/guide_repo.rb
+++ b/app/repos/guide_repo.rb
@@ -7,8 +7,17 @@ module Site
         guides.where(org:, version:, slug:).one!
       end
 
-      def all(org:, version:)
+      def all_with(org:, version:)
         guides.where(org:, version:).to_a
+      end
+
+      def latest_by_org
+        Content::DEFAULT_GUIDE_VERSIONS.to_h { |org, version|
+          [
+            org,
+            guides.where(org:, version:).order(guides[:position].asc)
+          ]
+        }
       end
     end
   end

--- a/app/templates/guides/index.html.erb
+++ b/app/templates/guides/index.html.erb
@@ -1,0 +1,32 @@
+<h1>Guides</h1>
+
+<h2>Hanami</h2>
+
+<ol data-testid="hanami-guides">
+  <% hanami_guides.each do |guide| %>
+    <li>
+      <a href="<%= guide.url_path %>"><%= guide.title %></a>
+    </li>
+  <% end %>
+</ol>
+
+<h2>Dry RB</h2>
+
+<ol data-testid="dry-rb-guides">
+  <% dry_rb_guides.each do |guide| %>
+    <li>
+      <a href="<%= guide.url_path %>"><%= guide.title %></a>
+    </li>
+  <% end %>
+</ol>
+
+
+<h2>ROM</h2>
+
+<ol data-testid="rom-guides">
+  <% rom_guides.each do |guide| %>
+    <li>
+      <a href="<%= guide.url_path %>"><%= guide.title %></a>
+    </li>
+  <% end %>
+</ol>

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -1,6 +1,6 @@
 <h2>All guides</h1>
 <ol data-testid="guides-list">
-  <% all_guides.each do |guide| %>
+  <% other_guides.each do |guide| %>
     <li>
       <a href="<%= guide.url_path %>">
         <%= guide.title %>

--- a/app/views/guides/index.rb
+++ b/app/views/guides/index.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Site
+  module Views
+    module Guides
+      class Index < Site::View
+        include Deps["repos.guide_repo"]
+
+        expose :hanami_guides do |guides|
+          guides.fetch("hanami")
+        end
+
+        expose :dry_rb_guides do |guides|
+          guides.fetch("dry-rb")
+        end
+
+        expose :rom_guides do |guides|
+          guides.fetch("rom")
+        end
+
+        private_expose :guides do
+          guide_repo.latest_by_org
+        end
+      end
+    end
+  end
+end

--- a/app/views/guides/show.rb
+++ b/app/views/guides/show.rb
@@ -14,8 +14,8 @@ module Site
           guide.pages.page_at(path)
         end
 
-        expose :all_guides do |org:, version:|
-          guide_repo.all(org:, version:)
+        expose :other_guides do |org:, version:|
+          guide_repo.all_with(org:, version:)
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ module Site
   class Routes < Hanami::Routes
     root to: "pages.home"
 
+    get "/guides", to: "guides.index"
     get "/guides/:org/:version/:slug", to: "guides.show"
     get "/guides/:org/:version/:slug/:path", to: "guides.show"
 

--- a/content/guides/dry-rb/v1.0/guides.yml
+++ b/content/guides/dry-rb/v1.0/guides.yml
@@ -1,0 +1,3 @@
+guides:
+  - slug: getting-started
+    title: Getting started

--- a/content/guides/rom/v5.0/guides.yml
+++ b/content/guides/rom/v5.0/guides.yml
@@ -1,0 +1,17 @@
+guides:
+  - slug: getting-started
+    title: Getting started
+  - slug: framework-integrations
+    title: Framework integrations
+  - slug: core-concepts
+    title: Core concepts
+  - slug: repositories
+    title: Repositories
+  - slug: changesets
+    title: Changesets
+  - slug: sql
+    title: SQL
+  - slug: http
+    title: HTTP
+  - slug: factories
+    title: Factories

--- a/spec/features/guides/guide_pages_spec.rb
+++ b/spec/features/guides/guide_pages_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Guides" do
+RSpec.feature "Guides / Guide pages" do
   it "renders a guide index page" do
     visit "/guides/hanami/v2.2/views"
 

--- a/spec/features/guides/index_page_spec.rb
+++ b/spec/features/guides/index_page_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.feature "Guides / Index page" do
+  it "lists all the guides across orgs" do
+    visit "/guides"
+
+    within "[data-testid=hanami-guides]" do
+      expect(page.find_all("li a").map(&:text)[0..2]).to eq [
+        "Getting started",
+        "Command line",
+        "App"
+      ]
+    end
+
+    within "[data-testid=dry-rb-guides]" do
+      expect(page.find_all("li a").map(&:text)[0..2]).to eq [
+        "Getting started"
+      ]
+    end
+
+    within "[data-testid=rom-guides]" do
+      expect(page.find_all("li a").map(&:text)[0..2]).to eq [
+        "Getting started",
+        "Framework integrations",
+        "Core concepts"
+      ]
+    end
+  end
+end


### PR DESCRIPTION
Add a `guides.yml` for Dry RB and ROM guides at the same time.