### PR TITLE
Link to headings in guide table of contents

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,10 @@ AllCops:
   SuggestExtensions: false
   TargetRubyVersion: 3.4
 
+# Disabled due to https://github.com/rubocop/rubocop-performance/issues/197
+Performance/ArraySemiInfiniteRangeSlice:
+  Enabled: false
+
 Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: always_true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,10 +8,6 @@ AllCops:
   SuggestExtensions: false
   TargetRubyVersion: 3.4
 
-# Disabled due to https://github.com/rubocop/rubocop-performance/issues/197
-Performance/ArraySemiInfiniteRangeSlice:
-  Enabled: false
-
 Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: always_true

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "sqlite3"
 # Markdown content handling
 gem "commonmarker"
 gem "front_matter_parser"
+gem "html-pipeline"
 
 # Static site generation
 gem "parklife"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,9 @@ GEM
       better_errors (~> 2.10, >= 2.10.1)
       binding_of_caller (~> 1.0)
     hansi (0.2.1)
+    html-pipeline (3.2.2)
+      selma (~> 0.4)
+      zeitwerk (~> 2.5)
     ice_nine (0.11.2)
     json (2.10.1)
     language_server-protocol (3.17.0.4)
@@ -320,6 +323,12 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    selma (0.4.12)
+      rb_sys (~> 0.9)
+    selma (0.4.12-aarch64-linux)
+    selma (0.4.12-arm64-darwin)
+    selma (0.4.12-x86_64-darwin)
+    selma (0.4.12-x86_64-linux)
     sequel (5.89.0)
       bigdecimal
     shellany (0.0.1)
@@ -386,6 +395,7 @@ DEPENDENCIES
   hanami-validations (~> 2.2)
   hanami-view (~> 2.2)
   hanami-webconsole (~> 2.2)
+  html-pipeline
   parklife
   puma
   rack-test

--- a/app/content/filters/linkable_headings_filter.rb
+++ b/app/content/filters/linkable_headings_filter.rb
@@ -35,7 +35,7 @@ module Site
 
           return unless heading_href.start_with?("#")
 
-          heading_id = heading_href.drop(1)
+          heading_id = heading_href[1..]
 
           element["id"] = heading_id
           element["class"] = "anchor"

--- a/app/content/filters/linkable_headings_filter.rb
+++ b/app/content/filters/linkable_headings_filter.rb
@@ -35,7 +35,7 @@ module Site
 
           return unless heading_href.start_with?("#")
 
-          heading_id = heading_href[1..-1]
+          heading_id = heading_href.drop(1)
 
           element["id"] = heading_id
           element["class"] = "anchor"

--- a/app/content/filters/linkable_headings_filter.rb
+++ b/app/content/filters/linkable_headings_filter.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Site
+  module Content
+    module Filters
+      # Extracts linkable headings (heading tags containing anchors) from the HTML and generates an
+      # array of `:headings` in the result hash.
+      #
+      # Each heading is a hash containing:
+      #
+      # - `:level` - the heading level (`1` for `"h1", etc.)
+      # - `:href` - the link to the heading, to be used in a table of contents
+      # - `:text` - the text of the heading
+      #
+      # Also adds a span within each heading which can be used to position a clickable link next for
+      # the heading:
+      #
+      #   <span aria-hidden="true" class="anchor"></span>
+      #
+      # Based on `HTMLPipeline::NodeFilter::TableOfContentsFilter`.
+      class LinkableHeadingsFilter < HTMLPipeline::NodeFilter
+        SELECTOR = Selma::Selector.new(
+          match_element: "h1 a[href], h2 a[href], h3 a[href], h4 a[href], h5 a[href], h6 a[href]",
+          match_text_within: "h1, h2, h3, h4, h5, h6"
+        )
+
+        def selector = SELECTOR
+
+        def after_initialize
+          result[:headings] = []
+        end
+
+        def handle_element(element)
+          heading_href = element["href"]
+
+          return unless heading_href.start_with?("#")
+
+          heading_id = heading_href[1..-1]
+
+          element["id"] = heading_id
+          element["class"] = "anchor"
+
+          # Add a span that can be used to show a "link" icon next to headings
+          element.set_inner_content(anchor_html, as: :html)
+
+          heading_level = Integer(element.ancestors.last.gsub(/[^0-9]/, ""))
+
+          result[:headings] << {level: heading_level, href: heading_href}
+        end
+
+        def handle_text_chunk(text)
+          result[:headings].last[:text] = text.to_s
+        end
+
+        private
+
+        def anchor_html
+          %(<span aria-hidden="true" class="anchor"></span>)
+        end
+      end
+    end
+  end
+end

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -27,7 +27,11 @@
 <ol data-testid="page-toc">
   <% page.headings.each do |heading| %>
     <%# TODO: do something with heading.header_level %>
-    <li><%= heading.text %></li>
+    <li>
+      <a href="<%= heading.href %>">
+        <%= heading.text %>
+      </a>
+    </li>
   <% end %>
 </ol>
 

--- a/spec/features/guides/guide_pages_spec.rb
+++ b/spec/features/guides/guide_pages_spec.rb
@@ -41,6 +41,12 @@ RSpec.feature "Guides / Guide pages" do
       expect(page).to have_selector "li:nth-child(3)", text: "Decorating context attributes"
       expect(page).to have_selector "li:nth-child(4)", text: "Providing an alternative context object"
     end
+
+    within "[data-testid=page-toc]" do
+      expect(page).to have_link "Standard context", href: "#standard-context"
+    end
+    heading_anchor = page.find("h2", exact_text: "Standard context").find("a")
+    expect(heading_anchor[:href]).to eq "#standard-context"
   end
 
   it "links to the other guides, in correct order" do


### PR DESCRIPTION
Use the html-pipeline gem so that we can parse the HTML generated from the markdown in order to find these headers.