### PR TITLE
Add internal links filter and first internal link type

### DIFF
--- a/app/content/filters/internal_links_filter.rb
+++ b/app/content/filters/internal_links_filter.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "html_pipeline"
+
+module Site
+  module Content
+    module Filters
+      # Replaces internal links with the format "//_link_type/some/extra/path".
+      #
+      # Expects an `:internal_links` hash to be provided in the context, with a transformation proc
+      # for each link type. Based on the above example, the following context should be provided:
+      #
+      # ```
+      # context: {
+      #   internal_links: {
+      #     link_type: ->(path) {
+      #       # transform the path here
+      #     }
+      #   }
+      # }
+      # ```
+      class InternalLinksFilter < HTMLPipeline::NodeFilter
+        SELECTOR = Selma::Selector.new(match_element: "a")
+
+        def selector = SELECTOR
+
+        def after_initialize
+          result[:internal_links] ||= {}
+        end
+
+        def handle_element(element)
+          href = element["href"]
+
+          begin
+            uri = URI.parse(href)
+          rescue
+            return
+          end
+
+          link_type = uri.host
+
+          return unless link_type&.start_with?("_")
+
+          replacement_proc = internal_links[link_type.sub(/^_/, "").to_sym]
+
+          return unless replacement_proc
+
+          element["href"] = replacement_proc.call(uri.path)
+        end
+
+        private
+
+        def internal_links = context[:internal_links]
+      end
+    end
+  end
+end

--- a/app/content/multi_page_collection.rb
+++ b/app/content/multi_page_collection.rb
@@ -34,6 +34,7 @@ module Site
         # TODO: figure out if there's value in passing `self` to the page, to
         # allow the page to expose its siblings, etc.
         Content::Page.new(
+          url_base: url_path,
           url_path: (path == INDEX_PAGE_PATH) ? url_path : File.join(url_path, path),
           front_matter: parsed_file.front_matter,
           content: parsed_file.content

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -35,4 +35,6 @@
   <% end %>
 </ol>
 
-<%= page.content_html %>
+<div class="content">
+  <%= page.content_html %>
+</div>

--- a/content/guides/hanami/v2.2/actions/_index.md
+++ b/content/guides/hanami/v2.2/actions/_index.md
@@ -44,4 +44,4 @@ end
 
 As the code above suggests, the `request` object provides access to the parameters associated with the incoming request through a `#params` method.
 
-Let's start by taking a look at action [parameters](/v2.2/actions/parameters/).
+Let's start by taking a look at action [parameters](//_guide/parameters).

--- a/spec/features/guides/guide_pages_spec.rb
+++ b/spec/features/guides/guide_pages_spec.rb
@@ -62,4 +62,13 @@ RSpec.feature "Guides / Guide pages" do
       ]
     end
   end
+
+  it "replaces guide:// URLs with URLs within the current guide and version" do
+    visit "/guides/hanami/v2.2/actions"
+
+    within ".content" do
+      # In `content/guides/hanami/v2.2/actions/_index.md`, this is linked as "//_guide/parameters"
+      expect(page).to have_link "parameters", href: "/guides/hanami/v2.2/actions/parameters"
+    end
+  end
 end


### PR DESCRIPTION
This filter makes it easy to link internally within guides. Rather than specifying the guide path and version in full, a link prefixed by "//_guide" can be used, with e.g. "//_guide/parameters" being transformed into "/guides/hanami/v2.2/actions/parameters".

Other internal links types will be introduced later.