### PR TITLE
Introduce "//guide" internal links

### DIFF
--- a/app/content/filters/internal_links_filter.rb
+++ b/app/content/filters/internal_links_filter.rb
@@ -1,3 +1,4 @@
+# auto_register: false
 # frozen_string_literal: true
 
 require "html_pipeline"
@@ -5,7 +6,7 @@ require "html_pipeline"
 module Site
   module Content
     module Filters
-      # Replaces internal links with the format "//_link_type/some/extra/path".
+      # Replaces internal links with the format "//link_type/some/extra/path".
       #
       # Expects an `:internal_links` hash to be provided in the context, with a transformation proc
       # for each link type. Based on the above example, the following context should be provided:
@@ -37,11 +38,9 @@ module Site
             return
           end
 
-          link_type = uri.host
+          return unless uri.scheme.nil? && !uri.host.to_s.empty?
 
-          return unless link_type&.start_with?("_")
-
-          replacement_proc = internal_links[link_type.sub(/^_/, "").to_sym]
+          replacement_proc = internal_links[uri.host.to_sym]
 
           return unless replacement_proc
 

--- a/app/content/page.rb
+++ b/app/content/page.rb
@@ -50,16 +50,35 @@ module Site
           content_md,
           context: {
             internal_links: {
-              guide: method(:guide_path)
+              page: method(:page_path),
+              guide: method(:guide_path),
+              org_guide: method(:org_guide_path)
             }
           }
         )
       end
 
-      # Replaces links to "//_guide/internal-page" with links within the current guide and
-      # version, such as "/guides/hanami/v2.2/some-guide/internal-page".
-      def guide_path(path)
+      # Transforms "//page/page-slug" into a path within the current guide and version, such as
+      # "/guides/hanami/v2.2/current-guide/page-slug".
+      def page_path(path)
         url_base + path
+      end
+
+      # Transforms "//guide/guide-slug/page-slug" into a path within the current version, such as
+      # "/guides/hanami/v2.2/guide-slug/page-slug".
+      #
+      # To link to the guide's index page, provide a guide slug only.
+      def guide_path(path)
+        url_base_without_slug = url_base.split("/")[0..-2].join("/")
+        url_base_without_slug + path
+      end
+
+      # Transforms "//org_guide/org-slug/guide-slug" into a versionless path for the guide within
+      # the given org.
+      #
+      # Visitors to that link will then be redirected to the latest version of the guide.
+      def org_guide_path(path)
+        "/guides/#{path}"
       end
     end
   end

--- a/content/guides/hanami/v2.2/actions/_index.md
+++ b/content/guides/hanami/v2.2/actions/_index.md
@@ -44,4 +44,4 @@ end
 
 As the code above suggests, the `request` object provides access to the parameters associated with the incoming request through a `#params` method.
 
-Let's start by taking a look at action [parameters](//_guide/parameters).
+Let's start by taking a look at action [parameters](//page/parameters).

--- a/content/guides/hanami/v2.2/getting-started/building-a-web-app.md
+++ b/content/guides/hanami/v2.2/getting-started/building-a-web-app.md
@@ -150,7 +150,7 @@ def handle(request, response)
 end
 ```
 
-For more details on actions, see the [Actions guide](/v2.2/actions/overview/).
+For more details on actions, see the [Actions guide](//guide/actions).
 
 By default, an action will render its equivalent view. We can find our new view in our `app` directory at `app/views/home/index.rb`:
 

--- a/spec/features/guides/guide_pages_spec.rb
+++ b/spec/features/guides/guide_pages_spec.rb
@@ -63,12 +63,21 @@ RSpec.feature "Guides / Guide pages" do
     end
   end
 
-  it "replaces guide:// URLs with URLs within the current guide and version" do
+  it "replaces //page URLs with URLs within the current guide and version" do
     visit "/guides/hanami/v2.2/actions"
 
     within ".content" do
-      # In `content/guides/hanami/v2.2/actions/_index.md`, this is linked as "//_guide/parameters"
+      # In the markdown, this is linked as "//page/parameters"
       expect(page).to have_link "parameters", href: "/guides/hanami/v2.2/actions/parameters"
+    end
+  end
+
+  it "transforms //guide links into links to a different guide within the current version" do
+    visit "/guides/hanami/v2.2/getting-started/building-a-web-app"
+
+    within ".content" do
+      # In the markdown, this is linked as "//guide/actions"
+      expect(page).to have_link "Actions guide", href: "/guides/hanami/v2.2/actions"
     end
   end
 end


### PR DESCRIPTION
These link to another guide within the current org and version.

While here, drop the need for these internal links to begin with a leading underscore. The link types without the underscore look cleaner, and given that these URLs appear as scheme-less with the link types as their host, there's no need to disambiguate them further.