### PR TITLE
Fix bug where toc header text would go missing

### DIFF
--- a/app/content/filters/linkable_headings_filter.rb
+++ b/app/content/filters/linkable_headings_filter.rb
@@ -46,11 +46,13 @@ module Site
 
           heading_level = Integer(element.ancestors.last.gsub(/[^0-9]/, ""))
 
-          result[:headings] << {level: heading_level, href: heading_href}
+          result[:headings] << {level: heading_level, href: heading_href, text: +""}
         end
 
         def handle_text_chunk(text)
-          result[:headings].last[:text] = text.to_s
+          # Concact text rather than assigning it, since a header may contain multiple text
+          # chunks, e.g. a "Keyword arguments (`kwargs`)" markdown header contains 3 text chunks.
+          result[:headings].last[:text].concat(text.to_s)
         end
 
         private

--- a/app/templates/doc_pages/_headings_toc.html.erb
+++ b/app/templates/doc_pages/_headings_toc.html.erb
@@ -1,12 +1,12 @@
-<ol data-testid="headings-toc">
+<%= tag.ol("data-testid" => testid) do %>
   <% headings.each do |(heading, child_headings)| %>
     <li>
       <a href="<%= heading.href %>">
         <%= heading.text %>
       </a>
       <% if child_headings.any? %>
-        <%= render "doc_pages/headings_toc", headings: child_headings %>
+        <%= render "doc_pages/headings_toc", headings: child_headings, testid: nil %>
       <% end %>
     </li>
   <% end %>
-</ol>
+<% end %>

--- a/app/templates/doc_pages/_pages_nav.html.erb
+++ b/app/templates/doc_pages/_pages_nav.html.erb
@@ -1,12 +1,12 @@
-<ol data-testid="pages-nav">
+<%= tag.ol("data-testid" => testid) do %>
   <% pages.each do |(page, child_pages)| %>
     <li>
       <a href="<%= page.url_path %>">
         <%= page.title %>
       </a>
       <% if child_pages.any? %>
-        <%= render "doc_pages/pages_nav", pages: child_pages %>
+        <%= render "doc_pages/pages_nav", pages: child_pages, testid: nil %>
       <% end %>
     </li>
   <% end %>
-</ol>
+<% end %>

--- a/app/templates/docs/show.html.erb
+++ b/app/templates/docs/show.html.erb
@@ -14,10 +14,10 @@
   <% end %>
 </div>
 
-<%= render "doc_pages/pages_nav", pages: doc.pages.nested %>
+<%= render "doc_pages/pages_nav", pages: doc.pages.nested, testid: "pages-nav" %>
 
 <h2>TOC</h2>
-<%= render "doc_pages/headings_toc", headings: page.nested_headings %>
+<%= render "doc_pages/headings_toc", headings: page.nested_headings, testid: "headings-toc" %>
 
 <main>
   <header>

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -19,10 +19,10 @@
   <h1><%= guide.title %></h1>
 </header>
 
-<%= render "doc_pages/pages_nav", pages: guide.pages.nested %>
+<%= render "doc_pages/pages_nav", pages: guide.pages.nested, testid: "pages-nav" %>
 
 <h2>TOC</h2>
-<%= render "doc_pages/headings_toc", headings: page.nested_headings %>
+<%= render "doc_pages/headings_toc", headings: page.nested_headings, testid: "headings-toc" %>
 
 <main>
   <header>

--- a/spec/features/docs/doc_pages_spec.rb
+++ b/spec/features/docs/doc_pages_spec.rb
@@ -75,6 +75,14 @@ RSpec.feature "Docs / Doc pages" do
     expect(heading_anchor[:href]).to eq "#basic-usage"
   end
 
+  it "shows a table of contents when headers use markdown formatting" do
+    visit "/docs/dry-auto_inject/v1.1/injection-strategies"
+
+    within "[data-testid=headings-toc]" do
+      expect(page).to have_selector "li", text: "Keyword arguments (kwargs)"
+    end
+  end
+
   it "replaces //page URLs with URLs within the current doc and version" do
     visit "/docs/dry-types/v1.8"
 


### PR DESCRIPTION
The problem was to do with Markdown-formatted headers that may contain multiple text chunks.

For example, a header of “Hello (`world`)” would yield text chunks of “Hello (“, “world”, and “)”, because that middle “world” chunk lived inside a nested code element.

Previously, our linkable headings filter was a little naive: it expexted a single text chunk per header and would directly assign each yielded text chunk to the header, resulting in the final chunk “winning” and becoming the text for the header.

Now, we concat each chunk as it comes, which results in properly complete header text for headers like this.