### PR TITLE
Add base implementation of a Table of Contents (TOC) scroll indicator

### DIFF
--- a/app/assets/css/content.css
+++ b/app/assets/css/content.css
@@ -85,6 +85,10 @@
     padding: calc(var(--spacing) * 5);
     margin-block-start: calc(var(--spacing) * 3);
     margin-block-end: calc(var(--spacing) * 5);
+
+    code {
+      padding: 0;
+    }
   }
 
   table {

--- a/app/assets/js/views/index.ts
+++ b/app/assets/js/views/index.ts
@@ -1,8 +1,10 @@
 import type { Views } from "@icelab/defo/dist/types";
 import { docsearchViewFn } from "./docsearch/docsearch";
 import { sizeToVarViewFn } from "./size-to-var";
+import { tocScrollViewFn } from "./toc-scroll";
 
 export const views: Views = {
   docsearch: docsearchViewFn,
   sizeToVar: sizeToVarViewFn,
+  tocScroll: tocScrollViewFn,
 };

--- a/app/assets/js/views/toc-scroll.test.ts
+++ b/app/assets/js/views/toc-scroll.test.ts
@@ -43,17 +43,17 @@ describe(findElements, () => {
   });
 
   it("finds anchors by id and name and maps them to TOC links", () => {
-    const { anchors, anchorToTocLinkMap, tocLinks } = findElements({
+    const { anchors, anchorToLinkMap, links } = findElements({
       anchorContainerSelector: "#main-content",
-      tocContainerNode: tocContainer,
-      tocNodeSelector: "a[href^='#']",
+      linkContainerNode: tocContainer,
+      linkSelector: "a[href^='#']",
     });
 
     expect(anchors.length).toBe(4);
 
-    // Each anchor should map to the correct TOC link
+    // Each anchor should map to the correct link
     anchors.forEach((anchor) => {
-      const link = anchorToTocLinkMap.get(anchor);
+      const link = anchorToLinkMap.get(anchor);
       expect(link).toBeInstanceOf(HTMLAnchorElement);
       if (anchor.id) {
         expect(link?.getAttribute("href")).toBe(`#${anchor.id}`);
@@ -62,18 +62,14 @@ describe(findElements, () => {
       }
     });
 
-    // tocLinks should include all 5 links
-    expect(tocLinks.length).toBe(5);
+    expect(links.length).toBe(5);
   });
 
   it("uses document as anchor container if selector is not provided", () => {
-    // Move anchors to document body
-    document.body.appendChild(anchorContainer);
-
     const { anchors } = findElements({
       anchorContainerSelector: undefined,
-      tocContainerNode: tocContainer,
-      tocNodeSelector: "a[href^='#']",
+      linkContainerNode: tocContainer,
+      linkSelector: "a[href^='#']",
     });
 
     expect(anchors.length).toBe(4);
@@ -83,8 +79,8 @@ describe(findElements, () => {
     expect(() =>
       findElements({
         anchorContainerSelector: "#does-not-exist",
-        tocContainerNode: tocContainer,
-        tocNodeSelector: "a[href^='#']",
+        linkContainerNode: tocContainer,
+        linkSelector: "a[href^='#']",
       }),
     ).toThrow();
   });

--- a/app/assets/js/views/toc-scroll.test.ts
+++ b/app/assets/js/views/toc-scroll.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { findClosestIndex } from "./toc-scroll";
+
+describe(findClosestIndex, () => {
+  const values = [0, 1, 3, 10, 11.5];
+  it("returns the correct value", () => {
+    expect(findClosestIndex(values, 0.6)).toBe(1);
+    expect(findClosestIndex(values, 9)).toBe(3);
+    expect(findClosestIndex(values, 11)).toBe(4);
+    expect(findClosestIndex(values, 100)).toBe(4);
+  });
+});

--- a/app/assets/js/views/toc-scroll.test.ts
+++ b/app/assets/js/views/toc-scroll.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { findClosestIndex } from "./toc-scroll";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { findClosestIndex, findElements } from "./toc-scroll";
 
 describe(findClosestIndex, () => {
   const values = [0, 1, 3, 10, 11.5];
@@ -8,5 +8,84 @@ describe(findClosestIndex, () => {
     expect(findClosestIndex(values, 9)).toBe(3);
     expect(findClosestIndex(values, 11)).toBe(4);
     expect(findClosestIndex(values, 100)).toBe(4);
+  });
+});
+
+describe(findElements, () => {
+  let tocContainer: HTMLElement;
+  let anchorContainer: HTMLElement;
+
+  beforeEach(() => {
+    // Set up DOM structure
+    tocContainer = document.createElement("nav");
+    tocContainer.innerHTML = `
+      <a href="#section1">Section 1</a>
+      <a href="#section2">Section 2</a>
+      <a href="#section2-1">Section 2.1</a>
+      <a href="#byname">By Name</a>
+      <a href="#missing">Missing</a>
+    `;
+
+    anchorContainer = document.createElement("div");
+    anchorContainer.innerHTML = `
+      <h2 id="section1">Section 1</h2>
+      <h2 id="section2">Section 2</h2>
+      <h3 id="section2-1">Section 2.1</h2>
+      <a name="byname">By Name</a>
+    `;
+    anchorContainer.id = "main-content";
+    document.body.appendChild(anchorContainer);
+    document.body.appendChild(tocContainer);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("finds anchors by id and name and maps them to TOC links", () => {
+    const { anchors, anchorToTocLinkMap, tocLinks } = findElements({
+      anchorContainerSelector: "#main-content",
+      tocContainerNode: tocContainer,
+      tocNodeSelector: "a[href^='#']",
+    });
+
+    expect(anchors.length).toBe(4);
+
+    // Each anchor should map to the correct TOC link
+    anchors.forEach((anchor) => {
+      const link = anchorToTocLinkMap.get(anchor);
+      expect(link).toBeInstanceOf(HTMLAnchorElement);
+      if (anchor.id) {
+        expect(link?.getAttribute("href")).toBe(`#${anchor.id}`);
+      } else if (anchor.getAttribute("name")) {
+        expect(link?.getAttribute("href")).toBe(`#${anchor.getAttribute("name")}`);
+      }
+    });
+
+    // tocLinks should include all 5 links
+    expect(tocLinks.length).toBe(5);
+  });
+
+  it("uses document as anchor container if selector is not provided", () => {
+    // Move anchors to document body
+    document.body.appendChild(anchorContainer);
+
+    const { anchors } = findElements({
+      anchorContainerSelector: undefined,
+      tocContainerNode: tocContainer,
+      tocNodeSelector: "a[href^='#']",
+    });
+
+    expect(anchors.length).toBe(4);
+  });
+
+  it("throws if anchor container selector is invalid and function is modified to throw", () => {
+    expect(() =>
+      findElements({
+        anchorContainerSelector: "#does-not-exist",
+        tocContainerNode: tocContainer,
+        tocNodeSelector: "a[href^='#']",
+      }),
+    ).toThrow();
   });
 });

--- a/app/assets/js/views/toc-scroll.ts
+++ b/app/assets/js/views/toc-scroll.ts
@@ -1,0 +1,114 @@
+export function tocScrollViewFn(
+  tocContainerNode: HTMLElement,
+  {
+    anchorContainerSelector,
+    tocNodeSelector = "a[href^='#']",
+  }: {
+    anchorContainerSelector?: string;
+    tocNodeSelector?: string;
+  },
+) {
+  const tocLinks = Array.from(
+    tocContainerNode.querySelectorAll<HTMLAnchorElement>(tocNodeSelector),
+  );
+
+  let anchorContainer: ParentNode = document;
+  if (anchorContainerSelector) {
+    const foundAnchorContainer = document.querySelector(anchorContainerSelector);
+    if (foundAnchorContainer) {
+      anchorContainer = foundAnchorContainer;
+    }
+  }
+
+  // Map: anchor element -> toc link
+  const anchorToTocLink = new Map<Element, HTMLAnchorElement>();
+
+  tocLinks.forEach((link) => {
+    const href = link.getAttribute("href");
+    if (!href || !href.startsWith("#")) return;
+    const id = href.slice(1);
+    // Try to find by ID or by name
+    const anchor =
+      anchorContainer.querySelector(`#${CSS.escape(id)}`) ||
+      anchorContainer.querySelector(`[name="${CSS.escape(id)}"]`);
+    if (anchor) {
+      anchorToTocLink.set(anchor, link);
+    }
+  });
+
+  const anchors = Array.from(anchorToTocLink.keys());
+
+  // 3. Set up IntersectionObserver
+  async function onScroll() {
+    const viewportMarginThreshold = window.innerHeight * 0.1;
+    const yPositions: number[] = [];
+    const resolvers: ((value: void | PromiseLike<void>) => void)[] = [];
+    const promises = anchors.map(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+
+    // This abuses IntersectionObserver to get the positions of each anchor element without causing
+    // reflows (when using `getBoundingClientRect` directly)
+    const observer = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        const { target, boundingClientRect } = entry;
+        const index = anchors.indexOf(target);
+
+        const { y } = boundingClientRect;
+        yPositions[index] = y;
+
+        const resolver = resolvers[index];
+        if (resolver) {
+          resolver();
+        } else {
+          throw new Error("Mismatch");
+        }
+      }
+
+      // Disconnect the observer immediately
+      observer.disconnect();
+    });
+
+    // Trigger observer for each anchor
+    anchors.forEach((anchor) => observer.observe(anchor));
+
+    await Promise.all(promises);
+
+    yPositions.unshift(window.scrollY * -1);
+    const closestIndex = findClosestIndex(yPositions, viewportMarginThreshold) - 1;
+    let activeAnchor = anchors[closestIndex];
+
+    if (activeAnchor) {
+      const activeLink = anchorToTocLink.get(activeAnchor);
+      if (activeLink) {
+        activateLink(activeLink);
+      }
+    } else {
+      activateLink(undefined);
+    }
+  }
+
+  window.addEventListener("scroll", onScroll);
+
+  function activateLink(activeLinkNode: HTMLElement | undefined) {
+    tocLinks.forEach((node) => node.classList.remove("text-rose-500"));
+    if (activeLinkNode) {
+      activeLinkNode.classList.add("text-rose-500");
+    }
+  }
+
+  return {
+    destroy: () => {
+      window.removeEventListener("scroll", onScroll);
+    },
+  };
+}
+
+const findClosestIndex = (arr: number[], target: number) =>
+  arr.reduce(
+    (closest, curr, i) => (Math.abs(curr - target) < Math.abs(arr[closest] - target) ? i : closest),
+    0,
+  );

--- a/app/assets/js/views/toc-scroll.ts
+++ b/app/assets/js/views/toc-scroll.ts
@@ -26,8 +26,7 @@ export function tocScrollViewFn(
 
   // Determine the initial position of the indicator (based on the position of the first link
   // element)
-  const firstLinkTuple = anchorToLinkMap.get(firstAnchor);
-  const firstLink = firstLinkTuple ? firstLinkTuple[0] : undefined;
+  const [firstLink] = anchorToLinkMap.get(firstAnchor)!;
   let indicatorPosition = {
     x: 0,
     y: firstLink?.offsetTop ?? 0,
@@ -99,7 +98,7 @@ export function findElements({
   const links = Array.from(linkContainerNode.querySelectorAll<HTMLAnchorElement>(linkSelector));
   // Resolve the indicator
   const indicator = indicatorSelector
-    ? document.querySelector<HTMLElement>(indicatorSelector)
+    ? (document.querySelector<HTMLElement>(indicatorSelector) ?? undefined)
     : undefined;
 
   // Resolve the container

--- a/app/assets/js/views/toc-scroll.ts
+++ b/app/assets/js/views/toc-scroll.ts
@@ -107,8 +107,20 @@ export function tocScrollViewFn(
   };
 }
 
-const findClosestIndex = (arr: number[], target: number) =>
-  arr.reduce(
-    (closest, curr, i) => (Math.abs(curr - target) < Math.abs(arr[closest] - target) ? i : closest),
-    0,
-  );
+/**
+ * findClosestIndex
+ * Find the value in the passed array closest to the `target`.
+ * @example
+ * const values = [1,2,10]
+ * findClosestIndex(values, 9)
+ * // -> 2
+ */
+export const findClosestIndex = (arr: number[], target: number) =>
+  arr.reduce((closestIndex, curr, i) => {
+    const closestIndexValue = arr[closestIndex] ?? 0;
+    if (Math.abs(curr - target) < Math.abs(closestIndexValue - target)) {
+      return i;
+    } else {
+      return closestIndex;
+    }
+  }, 0);

--- a/app/assets/js/views/toc-scroll.ts
+++ b/app/assets/js/views/toc-scroll.ts
@@ -1,22 +1,22 @@
 export function tocScrollViewFn(
-  tocContainerNode: HTMLElement,
+  linkContainerNode: HTMLElement,
   {
     anchorContainerSelector,
-    tocNodeSelector = "a[href^='#']",
+    linkSelector = "a[href^='#']",
   }: {
     anchorContainerSelector?: string;
-    tocNodeSelector?: string;
+    linkSelector?: string;
   },
 ) {
-  const { anchors, anchorToTocLinkMap, tocLinks } = findElements({
+  const { anchors, anchorToLinkMap, links } = findElements({
     anchorContainerSelector,
-    tocContainerNode,
-    tocNodeSelector,
+    linkContainerNode,
+    linkSelector,
   });
 
   function onChangeAnchor(activeAnchor: Element | undefined) {
-    const activeLinkNode = activeAnchor ? anchorToTocLinkMap.get(activeAnchor) : undefined;
-    tocLinks.forEach((node) => node.classList.remove("text-rose-500"));
+    const activeLinkNode = activeAnchor ? anchorToLinkMap.get(activeAnchor) : undefined;
+    links.forEach((node) => node.classList.remove("text-rose-500"));
     if (activeLinkNode) {
       activeLinkNode.classList.add("text-rose-500");
     }
@@ -36,18 +36,19 @@ export function tocScrollViewFn(
   };
 }
 
+/**
+ * Find all the elements we need:
+ */
 export function findElements({
   anchorContainerSelector,
-  tocContainerNode,
-  tocNodeSelector,
+  linkContainerNode,
+  linkSelector,
 }: {
   anchorContainerSelector: string | undefined;
-  tocContainerNode: HTMLElement;
-  tocNodeSelector: string;
+  linkContainerNode: HTMLElement;
+  linkSelector: string;
 }) {
-  const tocLinks = Array.from(
-    tocContainerNode.querySelectorAll<HTMLAnchorElement>(tocNodeSelector),
-  );
+  const links = Array.from(linkContainerNode.querySelectorAll<HTMLAnchorElement>(linkSelector));
 
   let anchorContainer: ParentNode = document;
   if (anchorContainerSelector) {
@@ -60,9 +61,9 @@ export function findElements({
   }
 
   // Map: anchor element -> toc link
-  const anchorToTocLinkMap = new Map<Element, HTMLAnchorElement>();
+  const anchorToLinkMap = new Map<Element, HTMLAnchorElement>();
 
-  tocLinks.forEach((link) => {
+  links.forEach((link) => {
     const href = link.getAttribute("href");
     if (!href || !href.startsWith("#")) return;
     const id = href.slice(1);
@@ -71,16 +72,16 @@ export function findElements({
       anchorContainer.querySelector(`#${CSS.escape(id)}`) ||
       anchorContainer.querySelector(`[name="${CSS.escape(id)}"]`);
     if (anchor) {
-      anchorToTocLinkMap.set(anchor, link);
+      anchorToLinkMap.set(anchor, link);
     }
   });
 
-  const anchors = Array.from(anchorToTocLinkMap.keys());
+  const anchors = Array.from(anchorToLinkMap.keys());
 
   return {
     anchors,
-    anchorToTocLinkMap,
-    tocLinks,
+    anchorToLinkMap,
+    links,
   };
 }
 

--- a/app/assets/js/views/toc-scroll.ts
+++ b/app/assets/js/views/toc-scroll.ts
@@ -21,7 +21,7 @@ export function tocScrollViewFn(
   }
 
   // Map: anchor element -> toc link
-  const anchorToTocLink = new Map<Element, HTMLAnchorElement>();
+  const anchorToTocLinkMap = new Map<Element, HTMLAnchorElement>();
 
   tocLinks.forEach((link) => {
     const href = link.getAttribute("href");
@@ -32,73 +32,26 @@ export function tocScrollViewFn(
       anchorContainer.querySelector(`#${CSS.escape(id)}`) ||
       anchorContainer.querySelector(`[name="${CSS.escape(id)}"]`);
     if (anchor) {
-      anchorToTocLink.set(anchor, link);
+      anchorToTocLinkMap.set(anchor, link);
     }
   });
 
-  const anchors = Array.from(anchorToTocLink.keys());
+  const anchors = Array.from(anchorToTocLinkMap.keys());
 
-  // 3. Set up IntersectionObserver
-  async function onScroll() {
-    const viewportMarginThreshold = window.innerHeight * 0.1;
-    const yPositions: number[] = [];
-    const resolvers: ((value: void | PromiseLike<void>) => void)[] = [];
-    const promises = anchors.map(
-      () =>
-        new Promise<void>((resolve) => {
-          resolvers.push(resolve);
-        }),
-    );
-
-    // This abuses IntersectionObserver to get the positions of each anchor element without causing
-    // reflows (when using `getBoundingClientRect` directly)
-    const observer = new IntersectionObserver((entries) => {
-      for (const entry of entries) {
-        const { target, boundingClientRect } = entry;
-        const index = anchors.indexOf(target);
-
-        const { y } = boundingClientRect;
-        yPositions[index] = y;
-
-        const resolver = resolvers[index];
-        if (resolver) {
-          resolver();
-        } else {
-          throw new Error("Mismatch");
-        }
-      }
-
-      // Disconnect the observer immediately
-      observer.disconnect();
-    });
-
-    // Trigger observer for each anchor
-    anchors.forEach((anchor) => observer.observe(anchor));
-
-    await Promise.all(promises);
-
-    yPositions.unshift(window.scrollY * -1);
-    const closestIndex = findClosestIndex(yPositions, viewportMarginThreshold) - 1;
-    let activeAnchor = anchors[closestIndex];
-
-    if (activeAnchor) {
-      const activeLink = anchorToTocLink.get(activeAnchor);
-      if (activeLink) {
-        activateLink(activeLink);
-      }
-    } else {
-      activateLink(undefined);
-    }
-  }
-
-  window.addEventListener("scroll", onScroll);
-
-  function activateLink(activeLinkNode: HTMLElement | undefined) {
+  function onChange(activeLinkNode: HTMLElement | undefined) {
     tocLinks.forEach((node) => node.classList.remove("text-rose-500"));
     if (activeLinkNode) {
       activeLinkNode.classList.add("text-rose-500");
     }
   }
+
+  const onScroll = createOnScrollFn({
+    anchors,
+    anchorToTocLinkMap,
+    onChange,
+  });
+
+  window.addEventListener("scroll", onScroll);
 
   return {
     destroy: () => {
@@ -124,3 +77,72 @@ export const findClosestIndex = (arr: number[], target: number) =>
       return closestIndex;
     }
   }, 0);
+
+/**
+ * Create the onScroll function
+ */
+function createOnScrollFn({
+  anchors,
+  anchorToTocLinkMap,
+  onChange,
+}: {
+  anchors: Element[];
+  anchorToTocLinkMap: Map<Element, HTMLAnchorElement>;
+  onChange: (activeLinkNode: HTMLElement | undefined) => void;
+}) {
+  return async () => {
+    const viewportMarginThreshold = window.innerHeight * 0.1;
+    const yPositions: number[] = [];
+
+    // Create an array of Promises and their resolver functions that matches the length of the
+    // `anchors` array.
+    const resolverFns: ((value: void | PromiseLike<void>) => void)[] = [];
+    const promises = anchors.map(
+      () =>
+        new Promise<void>((resolve) => {
+          resolverFns.push(resolve);
+        }),
+    );
+
+    // This abuses IntersectionObserver to get the positions of each anchor element without causing
+    // reflows (which would occur when using `getBoundingClientRect` directly).
+    const observer = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        const { target, boundingClientRect } = entry;
+        const index = anchors.indexOf(target);
+
+        const { y } = boundingClientRect;
+        yPositions[index] = y;
+
+        // Find the corresponding resolvedFn and call it.
+        const resolverFn = resolverFns[index];
+        if (resolverFn) {
+          resolverFn();
+        } else {
+          throw new Error("Mismatch between expect entries and resolvers");
+        }
+      }
+
+      // Disconnect the observer immediately after the entry resolves
+      observer.disconnect();
+    });
+
+    // Trigger observer for each anchor
+    anchors.forEach((anchor) => observer.observe(anchor));
+
+    // Wait for every item to be measured.
+    await Promise.all(promises);
+
+    // Add the window scrollY offset to the start of the yPosition array so we use it as an anchor
+    // to ensure we don’t always select the first item.
+    yPositions.unshift(window.scrollY * -1);
+
+    // Find the closest matching position (accounting for the fake value from the scroll position)
+    const closestIndex = findClosestIndex(yPositions, viewportMarginThreshold) - 1;
+    let activeAnchor = anchors[closestIndex];
+    const activeLink = activeAnchor ? anchorToTocLinkMap.get(activeAnchor) : undefined;
+
+    // Call the onChange callback
+    onChange(activeLink);
+  };
+}

--- a/app/assets/js/views/toc-scroll.ts
+++ b/app/assets/js/views/toc-scroll.ts
@@ -194,7 +194,7 @@ function createOnScrollFn({
     const observer = new IntersectionObserver((entries) => {
       for (const entry of entries) {
         const { target, boundingClientRect } = entry;
-        const index = anchors.indexOf(target);
+        const index = anchors.indexOf(target as HTMLElement);
 
         const { y } = boundingClientRect;
         yPositions[index] = y;

--- a/app/assets/js/views/toc-scroll.ts
+++ b/app/assets/js/views/toc-scroll.ts
@@ -68,8 +68,8 @@ export function tocScrollViewFn(
  * findClosestIndex(values, 9)
  * // -> 2
  */
-export const findClosestIndex = (arr: number[], target: number) =>
-  arr.reduce((closestIndex, curr, i) => {
+export function findClosestIndex(arr: number[], target: number) {
+  return arr.reduce((closestIndex, curr, i) => {
     const closestIndexValue = arr[closestIndex] ?? 0;
     if (Math.abs(curr - target) < Math.abs(closestIndexValue - target)) {
       return i;

--- a/app/assets/js/views/toc-scroll.ts
+++ b/app/assets/js/views/toc-scroll.ts
@@ -2,25 +2,70 @@ export function tocScrollViewFn(
   linkContainerNode: HTMLElement,
   {
     anchorContainerSelector,
+    indicatorSelector = ".toc-indicator",
     linkSelector = "a[href^='#']",
   }: {
     anchorContainerSelector?: string;
+    indicatorSelector?: string;
     linkSelector?: string;
   },
 ) {
-  const { anchors, anchorToLinkMap, links } = findElements({
+  const { anchors, anchorToLinkMap, indicator, links } = findElements({
     anchorContainerSelector,
+    indicatorSelector,
     linkContainerNode,
     linkSelector,
   });
 
-  function onChangeAnchor(activeAnchor: Element | undefined) {
-    const activeLinkNode = activeAnchor ? anchorToLinkMap.get(activeAnchor) : undefined;
-    links.forEach((node) => node.classList.remove("text-rose-500"));
-    if (activeLinkNode) {
-      activeLinkNode.classList.add("text-rose-500");
-    }
+  const firstAnchor = anchors[0];
+
+  // Failed to find anything, bail out
+  if (!indicator || !firstAnchor || links.length == 0) {
+    return;
   }
+
+  // Determine the initial position of the indicator (based on the position of the first link
+  // element)
+  const firstLinkTuple = anchorToLinkMap.get(firstAnchor);
+  const firstLink = firstLinkTuple ? firstLinkTuple[0] : undefined;
+  let indicatorPosition = {
+    x: 0,
+    y: firstLink?.offsetTop ?? 0,
+    initialY: firstLink?.offsetTop ?? 0,
+  };
+
+  const activeClass = "text-rose-500";
+  const xOffset = 12;
+  const xOffsetDepth = 4;
+  const onChangeAnchor = (activeAnchor: HTMLElement | undefined) => {
+    requestAnimationFrame(() => {
+      // Remove active class from all links
+      links.forEach((node) => node.classList.remove(activeClass));
+
+      // Find the active link tuple
+      const activeLinkTuple = activeAnchor ? anchorToLinkMap.get(activeAnchor) : undefined;
+      if (activeLinkTuple) {
+        const [activeLinkNode, depth] = activeLinkTuple;
+        // Add the active class
+        activeLinkNode.classList.add(activeClass);
+        // Calculate the position of the indicator
+        indicatorPosition = {
+          ...indicatorPosition,
+          x: xOffset + depth * xOffsetDepth,
+          y: activeLinkNode.offsetTop + activeLinkNode.offsetHeight / 2 - 13,
+        };
+      } else {
+        // If no match, set the x offset to 0 to hide it
+        indicatorPosition.x = 0;
+      }
+      // Calculate the rotation between the initial position and current one
+      const circumference = 2 * Math.PI * indicator.offsetWidth;
+      const distance = Math.abs(indicatorPosition.initialY - indicatorPosition.y);
+      const rotationInDegrees = (distance / circumference) * 360;
+      // Apply the transform
+      indicator.style.transform = `translate(${indicatorPosition.x}px, ${indicatorPosition.y}px) rotate(${rotationInDegrees}deg)`;
+    });
+  };
 
   const onScroll = createOnScrollFn({
     anchors,
@@ -41,15 +86,23 @@ export function tocScrollViewFn(
  */
 export function findElements({
   anchorContainerSelector,
+  indicatorSelector,
   linkContainerNode,
   linkSelector,
 }: {
   anchorContainerSelector: string | undefined;
+  indicatorSelector: string | undefined;
   linkContainerNode: HTMLElement;
   linkSelector: string;
 }) {
+  // Resolve the links
   const links = Array.from(linkContainerNode.querySelectorAll<HTMLAnchorElement>(linkSelector));
+  // Resolve the indicator
+  const indicator = indicatorSelector
+    ? document.querySelector<HTMLElement>(indicatorSelector)
+    : undefined;
 
+  // Resolve the container
   let anchorContainer: ParentNode = document;
   if (anchorContainerSelector) {
     const foundAnchorContainer = document.querySelector(anchorContainerSelector);
@@ -60,27 +113,33 @@ export function findElements({
     }
   }
 
-  // Map: anchor element -> toc link
-  const anchorToLinkMap = new Map<Element, HTMLAnchorElement>();
+  // Create a Map of the anchors to the [linkNode, linkDepth]
+  const anchorToLinkMap = new Map<HTMLElement, [HTMLAnchorElement, number]>();
 
+  // Iterate over the links and resolve their anchors.
   links.forEach((link) => {
     const href = link.getAttribute("href");
     if (!href || !href.startsWith("#")) return;
     const id = href.slice(1);
     // Try to find by ID or by name
     const anchor =
-      anchorContainer.querySelector(`#${CSS.escape(id)}`) ||
-      anchorContainer.querySelector(`[name="${CSS.escape(id)}"]`);
+      anchorContainer.querySelector<HTMLElement>(`#${CSS.escape(id)}`) ||
+      anchorContainer.querySelector<HTMLElement>(`[name="${CSS.escape(id)}"]`);
     if (anchor) {
-      anchorToLinkMap.set(anchor, link);
+      const depth = parseInt(link.dataset.depth || "0", 10);
+      anchorToLinkMap.set(anchor, [link, depth]);
+    } else {
+      throw new Error(`Anchor missing for link with href: ${href}`);
     }
   });
 
+  // Extract the anchors
   const anchors = Array.from(anchorToLinkMap.keys());
 
   return {
     anchors,
     anchorToLinkMap,
+    indicator,
     links,
   };
 }
@@ -114,8 +173,8 @@ function createOnScrollFn({
   anchors,
   onChangeAnchor,
 }: {
-  anchors: Element[];
-  onChangeAnchor: (activeAnchor: Element | undefined) => void;
+  anchors: HTMLElement[];
+  onChangeAnchor: (activeAnchor: HTMLElement | undefined) => void;
 }) {
   return async () => {
     const viewportMarginThreshold = window.innerHeight * WINDOW_THRESHOLD_PERCENTAGE;

--- a/app/templates/doc_pages/_headings_toc.html.erb
+++ b/app/templates/doc_pages/_headings_toc.html.erb
@@ -1,12 +1,19 @@
 <%= tag.ol("data-testid" => testid) do %>
   <% headings.each do |(heading, child_headings)| %>
     <li>
-      <a class="block py-1 text-gray-500" href="<%= heading.href %>">
+      <a
+        class="block py-1 text-gray-500"
+        data-depth="<%= depth %>"
+        href="<%= heading.href %>"
+      >
         <%= heading.text %>
       </a>
       <% if child_headings.any? %>
         <div class="border-gray-200 border-l-1 pl-3 ml-1">
-          <%= render "doc_pages/headings_toc", headings: child_headings, testid: nil %>
+          <%= render "doc_pages/headings_toc",
+          headings: child_headings,
+          testid: nil,
+          depth: depth + 1 %>
         </div>
       <% end %>
     </li>

--- a/app/templates/docs/show.html.erb
+++ b/app/templates/docs/show.html.erb
@@ -17,7 +17,7 @@
 <%= render "doc_pages/pages_nav", pages: doc.pages.nested, testid: "pages-nav", current_page_title: page.title %>
 <hr>
 <h2>TOC</h2>
-<%= render "doc_pages/headings_toc", headings: page.nested_headings, testid: "headings-toc" %>
+<%= render "doc_pages/headings_toc", headings: page.nested_headings, testid: "headings-toc", depth: 0 %>
 <hr>
 <main>
   <header>

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -36,12 +36,15 @@
 
   <section class="lg:col-span-13 lg:grid lg:grid-cols-13 md:col-span-4">
     <aside class="lg:col-span-3 lg:order-2">
-      <div class="lg:pt-8 lg:sticky lg:top-[calc(var(--hn-nav-height))] lg:overflow-y-auto lg:max-h-[calc(100vh-var(--hn-nav-height))] lg:h-full">
+      <div class="relative lg:pt-8 lg:sticky lg:top-[calc(var(--hn-nav-height))] lg:overflow-y-auto lg:overflow-x-hidden lg:max-h-[calc(100vh-var(--hn-nav-height))] lg:h-full">
         <div class="border-gray-200 lg:border-l-1 lg:pl-8 py-4" data-defo-toc-scroll="<%= {
             anchorContainerSelector: ".content",
           }.to_json %>">
           <h2 class="font-mono uppercase text-xs tracking-wider pt-1 mb-3">On this page</h2>
-          <%= render "doc_pages/headings_toc", headings: page.nested_headings, testid: "headings-toc" %>
+          <%= render "doc_pages/headings_toc", headings: page.nested_headings, testid: "headings-toc", depth: 0 %>
+          <div class="toc-indicator absolute right-full top-0 transition-transform ease-[cubic-bezier(.58,-.25,.265,1.25)] duration-500 fill-rose-500">
+            <svg height="28" viewBox="0 0 45 45" width="30" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="m45 22.55c0-3.8-3.85-6.2-7.7-6.15 2.45-2.7 3.85-7.1 1.15-9.75-2.7-2.7-7.1-1.65-9.85 1.1-.15-3.65-2.3-7.75-6.05-7.75-3.8 0-6.2 3.9-6.15 7.75-2.7-2.45-7.1-3.85-9.75-1.15-2.7 2.7-1.65 7.1 1.1 9.8-3.65.15-7.75 2.3-7.75 6.05 0 3.8 3.9 6.2 7.7 6.15-2.45 2.7-3.85 7.1-1.15 9.75 2.7 2.7 7.1 1.65 9.85-1.1.15 3.65 2.3 7.75 6.05 7.75 3.8 0 6.2-3.9 6.15-7.75 2.7 2.45 7.1 3.85 9.75 1.15 2.7-2.7 1.65-7.1-1.1-9.8 3.65-.15 7.75-2.3 7.75-6.05zm-22.5 7.5c-4.2 0-7.55-3.4-7.55-7.55 0-4.2 3.4-7.55 7.55-7.55s7.55 3.35 7.55 7.55-3.35 7.55-7.55 7.55z"/></g></svg>
+          </div>
         </div>
       </div>
     </aside>

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -37,7 +37,9 @@
   <section class="lg:col-span-13 lg:grid lg:grid-cols-13 md:col-span-4">
     <aside class="lg:col-span-3 lg:order-2">
       <div class="lg:pt-8 lg:sticky lg:top-[calc(var(--hn-nav-height))] lg:overflow-y-auto lg:max-h-[calc(100vh-var(--hn-nav-height))] lg:h-full">
-        <div class="border-gray-200 lg:border-l-1 lg:pl-8 py-4">
+        <div class="border-gray-200 lg:border-l-1 lg:pl-8 py-4" data-defo-toc-scroll="<%= {
+            anchorContainerSelector: ".content",
+          }.to_json %>">
           <h2 class="font-mono uppercase text-xs tracking-wider pt-1 mb-3">On this page</h2>
           <%= render "doc_pages/headings_toc", headings: page.nested_headings, testid: "headings-toc" %>
         </div>

--- a/app/templates/layouts/app.html.erb
+++ b/app/templates/layouts/app.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="scroll-pt-[calc(var(--hn-nav-height)+var(--spacing)*7)]">
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
Addresses #65.

Add a view function and some HTML structure for showing a scroll indicator alongside the Table of Contents (TOC) on Guide et al pages. Looks like this:

https://github.com/user-attachments/assets/65e62018-3e78-44a7-9441-915be8f48c61

There’s a few bits that I think we’ll want to do as the design fleshes out, but this gets the basics in place:

- [ ] Use the finalised flower SVGs (and the correct version per-project guide)
- [ ] Adjust the position of the flower for different depths. We might want to actually adjust the SVG slightly so they puff out from the centre or something?
- [ ] Better design for the indented guides (the additional line feels awkward)