### PR TITLE
Preload pages with foresight.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ db/*.sqlite
 log/*
 node_modules/
 public/
+!public/_headers
 !public/*.html
 !public/robots.txt
 spec/examples.txt

--- a/app/assets/js/utils/lazy-load.test.ts
+++ b/app/assets/js/utils/lazy-load.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "vitest";
+import { lazyLoadView } from "./lazy-load";
+
+type TestProps = { message: string };
+type ViewFn<P> = (node: HTMLElement, props: P) => void;
+
+const mockViewFn: ViewFn<TestProps> = (node, props) => {
+  node.textContent = props.message;
+};
+
+const importFn = async () => mockViewFn;
+
+test("should lazy load and invoke the view function with node and props", async () => {
+  const node = document.createElement("div");
+  const props = { message: "Hello, lazy!" };
+
+  const lazyFn = lazyLoadView(importFn);
+
+  await lazyFn(node, props);
+
+  expect(node.textContent).toBe("Hello, lazy!");
+});
+
+test("should work with different props", async () => {
+  const node = document.createElement("div");
+  const props = { message: "Another test" };
+
+  const lazyFn = lazyLoadView(importFn);
+  await lazyFn(node, props);
+
+  expect(node.textContent).toBe("Another test");
+});

--- a/app/assets/js/utils/lazy-load.ts
+++ b/app/assets/js/utils/lazy-load.ts
@@ -1,0 +1,18 @@
+import type { ViewFn, ViewProps } from "@icelab/defo";
+
+/**
+ * Lazy load wrapper for view functions
+ *
+ * Allows us to use a dynamic import to split the loading of view function out into separate bundles
+ * (as long as the bundler supports it).
+ *
+ * @example
+ * viewName: lazyLoadView(async () => {
+ *   const { viewNameFn } = await import("./view-name-fn");
+ *   return viewNameFn;
+ * })
+ */
+export const lazyLoadView = <T extends () => Promise<ViewFn<any>>>(importFn: T) => {
+  type Props = T extends () => Promise<ViewFn<infer P>> ? P : ViewProps;
+  return (node: HTMLElement, props: Props) => importFn().then((viewFn) => viewFn(node, props));
+};

--- a/app/assets/js/views/foresight.ts
+++ b/app/assets/js/views/foresight.ts
@@ -1,0 +1,27 @@
+import { ForesightManager } from "js.foresight";
+
+ForesightManager.initialize();
+
+type Props = {
+  elementSelector?: string;
+};
+
+const preloadedPaths = new Set();
+
+const createPreloadCallback = (href: string | null) => async () => {
+  if (!href || preloadedPaths.has(href)) {
+    return;
+  }
+  preloadedPaths.add(href);
+  await fetch(href);
+};
+
+export const foresightViewFn = (node: HTMLElement, { elementSelector = "a[href^='/']" }: Props) => {
+  const elements = [...node.querySelectorAll(elementSelector)];
+  elements.map((element) =>
+    ForesightManager.instance.register({
+      element,
+      callback: createPreloadCallback(element.getAttribute("href")),
+    }),
+  );
+};

--- a/app/assets/js/views/index.ts
+++ b/app/assets/js/views/index.ts
@@ -1,12 +1,17 @@
 import type { Views } from "@icelab/defo";
 
+import { breakpointFilter } from "~/utils/breakpoints";
+import { lazyLoadView } from "~/utils/lazy-load";
 import { docsearchViewFn } from "./docsearch/docsearch";
 import { sizeToVarViewFn } from "./size-to-var";
 import { tocScrollViewFn } from "./toc-scroll";
-import { breakpointFilter } from "~/utils/breakpoints";
 
 export const views: Views = {
   docsearch: docsearchViewFn,
   sizeToVar: sizeToVarViewFn,
   tocScroll: breakpointFilter(tocScrollViewFn),
+  foresight: lazyLoadView(async () => {
+    const { foresightViewFn } = await import("./foresight");
+    return foresightViewFn;
+  }),
 };

--- a/app/templates/layouts/app.html.erb
+++ b/app/templates/layouts/app.html.erb
@@ -21,7 +21,10 @@
     />
     <%= javascript_tag "app", async: true %>
   </head>
-  <body class="font-sans text-gray-800 bg-white">
+  <body
+    class="font-sans text-gray-800 bg-white"
+    data-defo-foresight="<%= { elementSelector: "a[href^='/']" }.to_json %>"
+  >
     <div class="flex flex-col max-w-[1540px] mx-auto">
       <header
         class="

--- a/config/assets.js
+++ b/config/assets.js
@@ -1,16 +1,19 @@
 import * as assets from "hanami-assets";
 
-await assets.run();
-
 // To provide additional esbuild (https://esbuild.github.io) options, use the following:
 //
 // Read more at: https://guides.hanamirb.org/assets/customization/
 //
-// await assets.run({
-//   esbuildOptionsFn: (args, esbuildOptions) => {
-//     // Add to esbuildOptions here. Use `args.watch` as a condition for different options for
-//     // compile vs watch.
-//
-//     return esbuildOptions;
-//   }
-// });
+await assets.run({
+  esbuildOptionsFn: (args, esbuildOptions) => {
+    // Add to esbuildOptions here. Use `args.watch` as a condition for different options for
+    // compile vs watch.
+    esbuildOptions = {
+      ...esbuildOptions,
+      format: "esm",
+      splitting: true,
+    };
+
+    return esbuildOptions;
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@icelab/defo": "^1.0.1",
         "@tailwindcss/cli": "^4.1.11",
         "hanami-assets": "^2.2.1",
+        "js.foresight": "^3.3.0",
         "lodash-es": "^4.17.21",
         "tailwindcss": "^4.1.11"
       },
@@ -1283,7 +1284,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2244,6 +2244,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js.foresight": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/js.foresight/-/js.foresight-3.3.0.tgz",
+      "integrity": "sha512-5+bMeZR7BwzqomPAZsK6TrqVV4m4GX5alQT5hrPBLIim1WTzPRX/c++3KD7Mqrk/Obe154yf6gn0FARukLv5kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "position-observer": "^1.0.1",
+        "tabbable": "^6.2.0"
+      }
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -2676,6 +2686,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/position-observer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/position-observer/-/position-observer-1.0.2.tgz",
+      "integrity": "sha512-BAswvZOcmjrxZTlr/fSbkhXyFeDDeNwEt0wCB2sdh9K9DO0NwjV1eY3ZP2SXeeAtwpkJS5cF8TqAOcCmEG/zCA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.41.1"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -2920,6 +2939,12 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@icelab/defo": "^1.0.1",
     "@tailwindcss/cli": "^4.1.11",
     "hanami-assets": "^2.2.1",
+    "js.foresight": "^3.3.0",
     "lodash-es": "^4.17.21",
     "tailwindcss": "^4.1.11"
   },

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,8 @@
+/*.html
+  Cache-Control: public, max-age=3600
+
+/*
+  Cache-Control: public, max-age=3600
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
This PR adds an implementation using [foresight.js](https://foresightjs.com) to preload links throughout the docs based on foresight’s heuristics for user-intent. Resolves #72.

### Implementation details

The implementation is pretty straightforward at the moment:

- We initialise the `foresight` view
- It finds all the elements on the page that match our `elementSelector`, which in this case is `a[^href="/"]` (aka any link that points to the current root of the current domain).
- We add register those elements with `foresight`

When foresight decides the user is intending to interact with one of those elements, we do one of two things:

- Issue a `fetch` to get the resolved `href` value
- Check if we’ve already fetched that href and do nothing

Our implementation isn’t responsible for any of the caching itself: that all defers to the browser’s internal caching mechanisms. All we’re doing is making that request ahead of time so the browser has it in its cache before the user actually clicks.

To get benefit from this, we need to ensure the pages we’re requesting are cached. To do that I’ve added some cache header rules to `public/_headers`.

### Bundle splitting

Foresight isn’t tiny, and its functionality is a nice-to-have, so I want to avoid putting it on the hot path. To support this I’ve added the ability to defer the loading of a module (using dynamic imports) and split that out in our asset build.

There are two parts to that:

- Adjusting the `esbuild` config to allow for `splitting: true` (we also need to change the format to `esm` to support this)
- Adding the `lazyLoadView` function that unwraps the import and calls the view function appropriately